### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/phpcheck.yml
+++ b/.github/workflows/phpcheck.yml
@@ -2,6 +2,9 @@ name: Psalm Static analysis
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   psalm:
     name: Psalm


### PR DESCRIPTION
Potential fix for [https://github.com/aejics/ReservaSalas/security/code-scanning/2](https://github.com/aejics/ReservaSalas/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. Since the Psalm static analysis workflow does not require write permissions, we can set the `contents` permission to `read`. This ensures that the `GITHUB_TOKEN` has the least privilege necessary to complete the task.

The `permissions` block should be added at the root level of the workflow file, so it applies to all jobs in the workflow. Alternatively, it can be added specifically to the `psalm` job if other jobs in the workflow require different permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
