### PR TITLE
fix(config.sample): remove Host Header Injection risk in OAuth redirectUri + doc improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Plataforma Digital para a Reserva de Salas e Respetivos Materiais. PAP (Prova de
 
 ## Dependências
 
-- PHP 8.4
+- PHP 8.4 (versão recomendada/testada; usar versão compatível com as dependências do Composer)
 - Servidor Web (recomendo o Caddy)
-- MariaDB ou MySQL (oficialmente recomendo o MariaDB)
+- MariaDB ou MySQL (oficialmente recomendo o MariaDB) — é necessário criar o utilizador e a base de dados antes de instalar (consultar o Manual do Técnico para instruções detalhadas)
 - Composer (para o Windows, descarregar [esta versão](https://getcomposer.org/Composer-Setup.exe))
 - Com o composer, fazer `composer install` através de um terminal, para instalar as dependências.
 

--- a/README.md
+++ b/README.md
@@ -9,12 +9,13 @@
 
 Plataforma Digital para a Reserva de Salas e Respetivos Materiais. PAP (Prova de Aptidão Profissional) - Marco Pisco - Curso de Técnico de Informática - Sistemas 12ºAno
 
-## Instalação (o básico)
+## Dependências
 
-- Necessário um servidor com PHP e uma DB MariaDB
+- PHP 8.4
+- Servidor Web (recomendo o Caddy)
+- MariaDB ou MySQL (oficialmente recomendo o MariaDB)
 - Composer (para o Windows, descarregar [esta versão](https://getcomposer.org/Composer-Setup.exe))
 - Com o composer, fazer `composer install` através de um terminal, para instalar as dependências.
-- Montar o utilizador usando as instruções [na wiki](https://github.com/marpisco/ClassLink/wiki/Configura%C3%A7%C3%A3o-MYSQL) (brevemente haverá mais documentação na Wiki)
 
 Informações específicas (e mais bem explicadas) estarão no Manual do Técnico.
 

--- a/src/config.sample.php
+++ b/src/config.sample.php
@@ -10,7 +10,8 @@
         'tipo' => 'mysql',         // Apenas há suporte a MYSQL (mysql = mariadb) por enquanto
         'servidor' => 'localhost',
         'user' => 'reservasalas',
-        'password' => 'salaspass', 
+        // Defina uma password forte antes de usar em produção e restrinja as permissões deste utilizador da DB ao mínimo necessário.
+        'password' => '',
         'db' => 'reservasalas',
         'porta' => 3306
     );

--- a/src/config.sample.php
+++ b/src/config.sample.php
@@ -21,11 +21,11 @@
         'servidor' => 'smtp.gmail.com',
         'porta' => 465,
         'autenticacao' => true,
-        // Tipo de Segurança: Explicação:
-        /// caso a autenticação seja por starttls, usar PHPMailer::ENCRYPTION_STARTTLS
-        /// caso a autenticação seja por ssl, usar PHPMailer::ENCRYPTION_SMTPS
-        /// caso não seja necessário autenticação, por false na opção autenticacao, e não importar-se para os outros
-        'tipodeseguranca' => 'PHPMailer::ENCRYPTION_STARTTLS ou PHPMailer::ENCRYPTION_SMTPS',
+        // Tipo de Segurança:
+        // - Para STARTTLS (normalmente porta 587), usar \PHPMailer\PHPMailer\PHPMailer::ENCRYPTION_STARTTLS
+        // - Para SMTPS/SSL (normalmente porta 465), usar \PHPMailer\PHPMailer\PHPMailer::ENCRYPTION_SMTPS
+        // - Se não for necessária autenticação, definir 'autenticacao' => false e ajustar esta opção conforme necessário
+        'tipodeseguranca' => \PHPMailer\PHPMailer\PHPMailer::ENCRYPTION_SMTPS,
         'username' => '',
         'fromname' => 'Reserva de Salas',
         'mailfrom' => '',

--- a/src/config.sample.php
+++ b/src/config.sample.php
@@ -1,16 +1,30 @@
 <?php
     require_once(__DIR__ . '/../vendor/autoload.php');
     use League\OAuth2\Client\Provider\GenericProvider;
+    /* Ficheiro de configuração
+       Mais informação sobre o ficheiro de configuração está na documentação.
+    */
 
-    // Email configuration
+    // Configuração da Base de Dados
+    $db = array(
+        'tipo' => 'mysql',         // Apenas há suporte a MYSQL (mysql = mariadb) por enquanto
+        'servidor' => 'localhost',
+        'user' => 'reservasalas',
+        'password' => 'salaspass', 
+        'db' => 'reservasalas',
+        'porta' => 3306
+    );
+        
+    // Configuração do servidor de email
     $mail = array(
         'ativado' => true,
         'servidor' => 'smtp.gmail.com',
         'porta' => 465,
         'autenticacao' => true,
-        // caso a autenticação seja por starttls, usar PHPMailer::ENCRYPTION_STARTTLS
-        // caso a autenticação seja por ssl, usar PHPMailer::ENCRYPTION_SMTPS
-        // caso não seja necessário autenticação, por false na opção autenticacao, e não importar-se para os outros
+        // Tipo de Segurança: Explicação:
+        /// caso a autenticação seja por starttls, usar PHPMailer::ENCRYPTION_STARTTLS
+        /// caso a autenticação seja por ssl, usar PHPMailer::ENCRYPTION_SMTPS
+        /// caso não seja necessário autenticação, por false na opção autenticacao, e não importar-se para os outros
         'tipodeseguranca' => 'PHPMailer::ENCRYPTION_STARTTLS ou PHPMailer::ENCRYPTION_SMTPS',
         'username' => '',
         'fromname' => 'Reserva de Salas',
@@ -18,25 +32,13 @@
         'password' => ''
     );
 
-    // Database configuration (MySQL/MariaDB)
-    // SECURITY: Use strong passwords and restrict database user permissions
-    $db = array(
-        'tipo' => 'mysql',
-        'servidor' => 'localhost',
-        'user' => 'reservasalas',
-        'password' => 'salaspass',  // CHANGE THIS to a strong password
-        'db' => 'reservasalas',
-        'porta' => 3306
-    );
-
-    // OAuth 2.0 configuration
-    // SECURITY: Keep clientId and clientSecret confidential
+    // Configuração do Fornecedor de Autenticação (OAuth 2.0)
     $provider = new GenericProvider([
         'urlAuthorize'            => 'https://authentik.devenv.marcopisco.com/application/o/authorize/',
         'urlAccessToken'          => 'https://authentik.devenv.marcopisco.com/application/o/token/',
         'urlResourceOwnerDetails' => 'https://authentik.devenv.marcopisco.com/application/o/userinfo/',
-        'clientId'     => 'clientid',  // CHANGE THIS
-        'clientSecret' => 'clientsecret',  // CHANGE THIS and keep it secret
+        'clientId'     => 'clientid',
+        'clientSecret' => 'clientsecret',
         'redirectUri'  => 'https://' . $_SERVER['HTTP_HOST'] . '/login'
     ]);
 ?>

--- a/src/config.sample.php
+++ b/src/config.sample.php
@@ -34,12 +34,15 @@
     );
 
     // Configuração do Fornecedor de Autenticação (OAuth 2.0)
+    // IMPORTANTE: Manter o clientSecret confidencial e nunca o expor publicamente.
+    // O redirectUri deve ser um URL estático/configurado explicitamente — não use $_SERVER['HTTP_HOST']
+    // diretamente pois pode ser manipulado (Host Header Injection).
     $provider = new GenericProvider([
-        'urlAuthorize'            => 'https://authentik.devenv.marcopisco.com/application/o/authorize/',
-        'urlAccessToken'          => 'https://authentik.devenv.marcopisco.com/application/o/token/',
-        'urlResourceOwnerDetails' => 'https://authentik.devenv.marcopisco.com/application/o/userinfo/',
-        'clientId'     => 'clientid',
-        'clientSecret' => 'clientsecret',
-        'redirectUri'  => 'https://' . $_SERVER['HTTP_HOST'] . '/login'
+        'urlAuthorize'            => 'https://exemplo.dominio.pt/application/o/authorize/',
+        'urlAccessToken'          => 'https://exemplo.dominio.pt/application/o/token/',
+        'urlResourceOwnerDetails' => 'https://exemplo.dominio.pt/application/o/userinfo/',
+        'clientId'     => '',
+        'clientSecret' => '',
+        'redirectUri'  => 'https://exemplo.dominio.pt/login'
     ]);
 ?>


### PR DESCRIPTION
`redirectUri` was built from `$_SERVER['HTTP_HOST']` without validation, enabling Host Header Injection in the OAuth flow. Reviewer comments also flagged hardcoded placeholder credentials and missing security guidance.

## Changes

**`src/config.sample.php`**
- Replace dynamic `redirectUri` with a static placeholder; add explicit comment warning against using `$_SERVER['HTTP_HOST']` directly
- Clear `clientId`/`clientSecret` values (were `'clientid'`/`'clientsecret'`) and replace example provider URLs with generic `exemplo.dominio.pt` placeholder
- Add security note to keep `clientSecret` confidential

```php
// IMPORTANTE: Manter o clientSecret confidencial e nunca o expor publicamente.
// O redirectUri deve ser um URL estático/configurado explicitamente — não use $_SERVER['HTTP_HOST']
// diretamente pois pode ser manipulado (Host Header Injection).
$provider = new GenericProvider([
    ...
    'clientId'     => '',
    'clientSecret' => '',
    'redirectUri'  => 'https://exemplo.dominio.pt/login'
]);
```

**`README.md`**
- Qualify PHP 8.4 as recommended/tested version rather than a hard requirement
- Re-add MariaDB/MySQL user setup step (lost in previous refactor), pointing to Manual do Técnico