### PR TITLE
Issue #135: use DB-configured sender name for emails

### DIFF
--- a/admin/scripts/notifyemail.php
+++ b/admin/scripts/notifyemail.php
@@ -737,7 +737,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['subject']) && isset($
                 $mailer->CharSet = 'UTF-8';
                 $mailer->Encoding = 'base64';
                 
-                $mailer->setFrom($mail['mailfrom'], $mail['fromname']);
+                // Prefer sender name from DB ('email_account_name'), fall back to config.php value or default
+                require_once(__DIR__ . '/../../func/get_config.php');
+                $fromName = get_app_config('email_account_name', $mail['fromname'] ?? 'ClassLink');
+                $mailer->setFrom($mail['mailfrom'], $fromName);
                 
                 if ($identifySender && !empty($_SESSION['email'])) {
                     $mailer->addReplyTo($_SESSION['email'], $_SESSION['nome']);

--- a/func/email_helper.php
+++ b/func/email_helper.php
@@ -11,6 +11,7 @@ require_once(__DIR__ . '/../vendor/phpmailer/phpmailer/src/Exception.php');
 require_once(__DIR__ . '/../vendor/phpmailer/phpmailer/src/PHPMailer.php');
 require_once(__DIR__ . '/../vendor/phpmailer/phpmailer/src/SMTP.php');
 require_once(__DIR__ . '/../src/config.php');
+require_once(__DIR__ . '/get_config.php');
 
 /**
  * Get the safe base URL for the application
@@ -147,7 +148,9 @@ function sendStyledEmail($to, $subject, $heading, $bodyContent, $type = 'info', 
         $mailer->CharSet = 'UTF-8';
         $mailer->Encoding = 'base64';
         
-        $mailer->setFrom($mail['mailfrom'], $mail['fromname']);
+        // Prefer sender name from DB config ('email_account_name'), fall back to config.php value or default
+        $fromName = get_app_config('email_account_name', $mail['fromname'] ?? 'ClassLink');
+        $mailer->setFrom($mail['mailfrom'], $fromName);
         $mailer->addAddress($to);
         
         $mailer->isHTML(true);

--- a/src/config.sample.php
+++ b/src/config.sample.php
@@ -28,7 +28,6 @@
         // - Se não for necessária autenticação, definir 'autenticacao' => false e ajustar esta opção conforme necessário
         'tipodeseguranca' => \PHPMailer\PHPMailer\PHPMailer::ENCRYPTION_SMTPS,
         'username' => '',
-        'fromname' => 'Reserva de Salas',
         'mailfrom' => '',
         'password' => ''
     );


### PR DESCRIPTION
Use DB config key 'email_account_name' as sender name for outgoing emails with fallback to legacy config; updates func/email_helper.php and admin/scripts/notifyemail.php; removes 'fromname' from src/config.sample.php.

Manual testing: send test email and verify From name matches DB value.