### PR TITLE
fix(admin): navbar theme not applied on page load — defer to DOMContentLoaded

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -198,7 +198,7 @@
     }
     echo "<li class='nav-item'><a href='/' class='nav-link'>Voltar</a></li>";
     // Fechar Navbar no HTML, e passar o conteúdo para baixo
-    echo "</ul></div></div></nav><div class='container-fluid mt-4 justify-content-center text-center'>";
+    echo "</ul></div></div></nav><script>window.__applyNavbarTheme&&window.__applyNavbarTheme();</script><div class='container-fluid mt-4 justify-content-center text-center'>";
 
     $csrfTokenHtml = htmlspecialchars(generate_csrf_token(), ENT_QUOTES, 'UTF-8');
     echo "<input type='hidden' id='global-csrf-token' value='{$csrfTokenHtml}'>";

--- a/assets/theme-switcher.js
+++ b/assets/theme-switcher.js
@@ -2,29 +2,39 @@
 (function() {
     const htmlElement = document.documentElement;
     const darkModeQuery = window.matchMedia('(prefers-color-scheme: dark)');
-    
-    // Function to apply theme
-    function applyTheme(isDark) {
-        htmlElement.setAttribute('data-bs-theme', isDark ? 'dark' : 'light');
-        
-        // Handle admin navbar specifically
+
+    // Set data-bs-theme immediately (before DOM is ready) to avoid flash of wrong theme
+    htmlElement.setAttribute('data-bs-theme', darkModeQuery.matches ? 'dark' : 'light');
+
+    // Handle admin navbar — deferred until DOM is ready so #admin-navbar exists
+    function applyNavbarTheme(isDark) {
         const adminNavbar = document.getElementById('admin-navbar');
-        if (adminNavbar) {
-            if (isDark) {
-                adminNavbar.classList.remove('navbar-light', 'bg-light');
-                adminNavbar.classList.add('navbar-dark', 'bg-dark');
-            } else {
-                adminNavbar.classList.remove('navbar-dark', 'bg-dark');
-                adminNavbar.classList.add('navbar-light', 'bg-light');
-            }
+        if (!adminNavbar) return;
+        if (isDark) {
+            adminNavbar.classList.remove('navbar-light', 'bg-light');
+            adminNavbar.classList.add('navbar-dark', 'bg-dark');
+        } else {
+            adminNavbar.classList.remove('navbar-dark', 'bg-dark');
+            adminNavbar.classList.add('navbar-light', 'bg-light');
         }
     }
-    
-    // Set initial theme based on system preference
-    applyTheme(darkModeQuery.matches);
-    
+
+    function applyTheme(isDark) {
+        htmlElement.setAttribute('data-bs-theme', isDark ? 'dark' : 'light');
+        applyNavbarTheme(isDark);
+    }
+
+    // Apply navbar classes once the DOM is ready
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', function () {
+            applyNavbarTheme(darkModeQuery.matches);
+        });
+    } else {
+        applyNavbarTheme(darkModeQuery.matches);
+    }
+
     // Listen for changes in system theme preference
-    darkModeQuery.addEventListener('change', e => {
+    darkModeQuery.addEventListener('change', function (e) {
         applyTheme(e.matches);
     });
 })();

--- a/assets/theme-switcher.js
+++ b/assets/theme-switcher.js
@@ -6,7 +6,7 @@
     // Set data-bs-theme immediately (before DOM is ready) to avoid flash of wrong theme
     htmlElement.setAttribute('data-bs-theme', darkModeQuery.matches ? 'dark' : 'light');
 
-    // Handle admin navbar — deferred until DOM is ready so #admin-navbar exists
+    // Handle admin navbar class switching
     function applyNavbarTheme(isDark) {
         const adminNavbar = document.getElementById('admin-navbar');
         if (!adminNavbar) return;
@@ -19,21 +19,26 @@
         }
     }
 
+    // Exposed for inline <script> placed right after the navbar HTML — runs
+    // synchronously before paint, so there is no flash of wrong navbar theme.
+    window.__applyNavbarTheme = function () {
+        applyNavbarTheme(darkModeQuery.matches);
+    };
+
+    // DOMContentLoaded fallback (e.g. if the inline call is missing or navbar
+    // is added dynamically after page load)
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', function () {
+            applyNavbarTheme(darkModeQuery.matches);
+        });
+    }
+
     function applyTheme(isDark) {
         htmlElement.setAttribute('data-bs-theme', isDark ? 'dark' : 'light');
         applyNavbarTheme(isDark);
     }
 
-    // Apply navbar classes once the DOM is ready
-    if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', function () {
-            applyNavbarTheme(darkModeQuery.matches);
-        });
-    } else {
-        applyNavbarTheme(darkModeQuery.matches);
-    }
-
-    // Listen for changes in system theme preference
+    // Listen for changes in system theme preference (live OS toggle)
     darkModeQuery.addEventListener('change', function (e) {
         applyTheme(e.matches);
     });


### PR DESCRIPTION
`theme-switcher.js` was loaded in `<head>`, before `#admin-navbar` existed in the DOM. The initial `applyTheme()` call silently failed to switch navbar classes (`navbar-dark`/`bg-dark` ↔ `navbar-light`/`bg-light`).

Only the `MatchMedia` change listener worked — the navbar only got correct theme classes after a live OS theme toggle, never on initial page load or after navigating to another admin page.

## What changed
- `data-bs-theme` is still set immediately in `<head>` (avoids flash of wrong theme)
- `window.__applyNavbarTheme` exposed by `theme-switcher.js`
- Inline `<script>` placed immediately after the navbar HTML calls it synchronously — runs before paint, no flash
- `DOMContentLoaded` listener retained as fallback
- `MatchMedia` change listener handles live OS theme toggles

Closes #157