### PR TITLE
Adicionar token CSRF a ações em massa em admin/pedidos.php

### DIFF
--- a/admin/pedidos.php
+++ b/admin/pedidos.php
@@ -1302,6 +1302,17 @@ function submitBulkAction(action, reservations) {
     input.value = JSON.stringify(reservations);
     
     form.appendChild(input);
+
+    const tokenSource = document.getElementById('global-csrf-token');
+    const csrfToken = tokenSource ? tokenSource.value : '';
+    if (csrfToken) {
+        const csrfInput = document.createElement('input');
+        csrfInput.type = 'hidden';
+        csrfInput.name = 'csrf_token';
+        csrfInput.value = csrfToken;
+        form.appendChild(csrfInput);
+    }
+
     document.body.appendChild(form);
     form.submit();
 }


### PR DESCRIPTION
### Motivation
- Corrigir envio de formulários dinâmicos que faltavam o token CSRF, evitando falhas na verificação de CSRF para ações em massa.
- Garantir que as rotas de bulk (`bulk_approve` / `bulk_reject`) que usam a função dinâmica incluam explicitamente `csrf_token` antes do envio.

### Description
- Atualiza `admin/pedidos.php` na função JavaScript `submitBulkAction(action, reservations)` para ler o valor de `document.getElementById('global-csrf-token')` e, se presente, criar um `<input type="hidden" name="csrf_token">` com esse valor.
- O input `csrf_token` é anexado ao formulário dinâmico antes de `document.body.appendChild(form)` e `form.submit()`, cobrindo tanto `bulk_approve` quanto `bulk_reject` que reutilizam a mesma função.
- Não foi alterado o comportamento de submissão para `requestSubmit()`; a correção é apenas a adição manual do campo `csrf_token`.

### Testing
- Executado `php -l admin/pedidos.php` e a verificação de sintaxe retornou sem erros.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a467231fa488325927da95882fa3fc1)