### PR TITLE
Fix admin log table wrapping

### DIFF
--- a/admin/registos.php
+++ b/admin/registos.php
@@ -7,6 +7,12 @@
         width: 100%;
         table-layout: fixed;
     }
+    #logsTable th,
+    #logsTable td {
+        overflow-wrap: anywhere;
+        word-break: break-word;
+        vertical-align: middle;
+    }
     #logsTable th:nth-child(1),
     #logsTable td:nth-child(1) {
         width: 20%;
@@ -56,8 +62,16 @@
         color: #6c757d;
         font-style: italic;
     }
+    .log-cell-wrap {
+        overflow-wrap: anywhere;
+        word-break: break-word;
+    }
     .ip-visible {
+        display: inline-block;
+        max-width: 100%;
         font-family: monospace;
+        overflow-wrap: anywhere;
+        word-break: break-all;
     }
 </style>
 
@@ -146,17 +160,19 @@
                     
                     // Utilizador column (name + email)
                     const userCell = document.createElement('td');
+                    userCell.className = 'log-cell-wrap';
                     userCell.innerHTML = '<strong>' + escapeHtml(log.nome || 'Utilizador removido') + '</strong><br><small class="text-muted">' + escapeHtml(log.email || 'N/A') + '</small>';
                     tr.appendChild(userCell);
                     
                     // Action column
                     const actionCell = document.createElement('td');
+                    actionCell.className = 'log-cell-wrap';
                     actionCell.innerHTML = createActionCell(log.id, log.loginfo);
                     tr.appendChild(actionCell);
                     
                     // IP Address column (hidden by default)
                     const ipCell = document.createElement('td');
-                    ipCell.className = 'ip-cell';
+                    ipCell.className = 'ip-cell log-cell-wrap';
                     ipCell.setAttribute('data-ip', log.ip_address || 'N/A');
                     if (showIPs) {
                         ipCell.innerHTML = '<span class="ip-visible">' + escapeHtml(log.ip_address || 'N/A') + '</span>';
@@ -167,6 +183,7 @@
                     
                     // Timestamp column
                     const timestampCell = document.createElement('td');
+                    timestampCell.className = 'log-cell-wrap';
                     timestampCell.textContent = log.timestamp;
                     tr.appendChild(timestampCell);
                     


### PR DESCRIPTION
### Motivation
- Prevent long log cell content (especially IPv6 addresses) from overflowing adjacent columns in the admin logs table.
- Preserve horizontal scrolling on very small screens while allowing normal wrapping inside fixed-width table cells.
- Keep existing HTML escaping in place to avoid introducing XSS vectors when rendering dynamic values.

### Description
- Add a shared rule targeting `#logsTable th, #logsTable td` to set `overflow-wrap: anywhere;`, `word-break: break-word;` and `vertical-align: middle;` in `admin/registos.php`.
- Introduce a reusable `.log-cell-wrap` class and apply it to dynamically generated `td` elements for user, action, IP, and timestamp cells inside `loadLogs()`.
- Enhance `.ip-visible` to use `font-family: monospace; display: inline-block; max-width: 100%; overflow-wrap: anywhere;` and `word-break: break-all;` so long IPv6 strings can wrap inside the IP column.
- Preserve the `.table-responsive` wrapper and continue using the existing `escapeHtml()` function when injecting dynamic content.

### Testing
- Ran `php -l admin/registos.php` which reported no syntax errors (PASS).
- Executed a `python3` static verification script that checks for the shared cell wrap rules, `.table-responsive` retention, `.ip-visible` updates, dynamic cell class additions, and that `escapeHtml()` is still used (PASS).
- Ran `git diff --check` which reported no whitespace or diff issues (PASS).
- Attempted `npx --yes playwright install chromium` for browser verification but the browser download failed with `403 Domain forbidden`, so automated browser rendering verification could not complete (FAIL).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46d41d0ba08325ac62ada5e414d834)