### PR TITLE
fix(reservas): unify filter button states

### DIFF
--- a/reservas/index.php
+++ b/reservas/index.php
@@ -153,15 +153,40 @@ $stmt->close();
             to { opacity: 1; transform: translateY(0); }
         }
         .filter-btn {
+            border-color: #0d6efd;
             border-radius: 20px;
+            color: #0a58ca;
             padding: 0.4rem 1rem;
             font-size: 0.9rem;
             transition: all 0.2s ease;
+            background: transparent;
         }
-        .filter-btn.active {
+        .filter-btn:hover {
+            background-color: #e7f1ff;
+            border-color: #0a58ca;
+            color: #084298;
+        }
+        .filter-btn.active,
+        .filter-btn.active:hover {
             background-color: #0d6efd;
-            color: white;
+            color: #fff;
             border-color: #0d6efd;
+            font-weight: 700;
+        }
+        [data-bs-theme="dark"] .filter-btn {
+            border-color: #6ea8fe;
+            color: #9ec5fe;
+        }
+        [data-bs-theme="dark"] .filter-btn:hover {
+            background-color: #0d6efd;
+            border-color: #9ec5fe;
+            color: #fff;
+        }
+        [data-bs-theme="dark"] .filter-btn.active,
+        [data-bs-theme="dark"] .filter-btn.active:hover {
+            background-color: #0d6efd;
+            border-color: #6ea8fe;
+            color: #fff;
         }
         .reservations-container {
             max-width: 1200px;
@@ -252,10 +277,10 @@ $stmt->close();
                 <div class="row g-3 align-items-center">
                     <div class="col-md-6">
                         <div class="btn-group" role="group">
-                            <button type="button" class="btn btn-outline-secondary filter-btn active" onclick="filterReservations('all', event)">Todas</button>
-                            <button type="button" class="btn btn-outline-warning filter-btn" onclick="filterReservations('pending', event)">Pendentes</button>
-                            <button type="button" class="btn btn-outline-success filter-btn" onclick="filterReservations('approved', event)">Aprovadas</button>
-                            <button type="button" class="btn btn-outline-primary filter-btn" onclick="filterReservations('future', event)">Futuras</button>
+                            <button type="button" class="btn filter-btn active" onclick="filterReservations('all', event)">Todas</button>
+                            <button type="button" class="btn filter-btn" onclick="filterReservations('pending', event)">Pendentes</button>
+                            <button type="button" class="btn filter-btn" onclick="filterReservations('approved', event)">Aprovadas</button>
+                            <button type="button" class="btn filter-btn" onclick="filterReservations('future', event)">Futuras</button>
                         </div>
                     </div>
                     <div class="col-md-6">


### PR DESCRIPTION
### Motivation
- Make the reservation filter buttons share a single visual style so hover/active states are consistent while preserving the existing filtering behavior.
- Ensure the selected state is visually stronger (`font-weight: 700` and white text) and maintains accessible contrast in both light and dark modes.

### Description
- Consolidated button markup from multiple Bootstrap outline variants to a shared `btn filter-btn` class on the four filter buttons in `reservas/index.php`.
- Replaced the previous `.filter-btn` rules with a single set that defines base appearance, a unified hover style (`.filter-btn:hover`), and an ensured selected style (`.filter-btn.active` and `.filter-btn.active:hover`) that forces `color: #fff` and `font-weight: 700`.
- Added dark-mode overrides using `[data-bs-theme="dark"]` rules to preserve contrast and make hover/active states consistent when dark theme is active.
- Did not change the JavaScript filtering logic apart from relying on the existing `.filter-btn` selector for active state management.

### Testing
- Ran `php -l reservas/index.php` to validate PHP syntax and it reported no syntax errors.
- Ran `git diff --check` to validate whitespace/merge issues and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49c100f4608325a3000e1d190fb0b8)