### PR TITLE
fix(reservas): align table header with theme

### DIFF
--- a/reservas/index.php
+++ b/reservas/index.php
@@ -193,6 +193,22 @@ $stmt->close();
             margin: 0 auto;
             padding: 20px;
         }
+        .reservations-table-head th {
+            --bs-table-bg: var(--bs-card-bg);
+            --bs-table-color: var(--bs-body-color);
+            --bs-table-border-color: var(--bs-border-color);
+            background-color: var(--bs-card-bg);
+            color: var(--bs-body-color);
+            border-color: var(--bs-border-color);
+        }
+        [data-bs-theme="dark"] .reservations-table-head th {
+            --bs-table-bg: var(--bs-tertiary-bg);
+            --bs-table-color: var(--bs-body-color);
+            --bs-table-border-color: var(--bs-border-color);
+            background-color: var(--bs-tertiary-bg);
+            color: var(--bs-body-color);
+            border-color: var(--bs-border-color);
+        }
         @media (max-width: 768px) {
             .stat-number {
                 font-size: 1.5rem;
@@ -317,7 +333,7 @@ $stmt->close();
                 } else {
                     echo "<div class='table-responsive'>
                             <table class='table table-hover align-middle mb-0' id='reservationsTable'>
-                                <thead class='table-light'>
+                                <thead class='reservations-table-head'>
                                     <tr>
                                         <th scope='col'>Sala</th>
                                         <th scope='col'>Data</th>


### PR DESCRIPTION
### Motivation

- Make the reservations table header match the surrounding card/table surface in light mode and switch to a darker readable surface in dark mode.
- Ensure header borders and text remain readable under both themes while keeping the visual system consistent with existing theme variables. 
- Preserve the existing table columns: `Sala`, `Data`, `Horário`, `Estado`, and `Ações`.

### Description

- Replaced the Bootstrap header class in `reservas/index.php` from `<thead class='table-light'>` to `<thead class='reservations-table-head'>` so the header can be themed independently. 
- Added CSS in the page's `<style>` block for `.reservations-table-head th` that uses theme variables (`--bs-card-bg`, `--bs-body-color`, `--bs-border-color`) to match the card/table surface in light mode. 
- Added a dark-mode override using `[data-bs-theme="dark"] .reservations-table-head th` that switches the header surface to a darker token (`--bs-tertiary-bg`) while keeping text and border colors readable. 
- Change is limited to `reservas/index.php` and does not alter any table columns or row logic.

### Testing

- Ran `php -l reservas/index.php` to validate PHP syntax and it succeeded. 
- Ran `git diff --check` to verify no whitespace/patch issues and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49c101fdd08325b829a6d1d2cb4e91)