### PR TITLE
fix(admin): add logo to admin navbar

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -105,7 +105,7 @@
         // Ensure navbar has an opaque background so page content doesn't show through when scrolling
         echo "<nav class='navbar navbar-expand-lg border-bottom navbar-dark bg-dark' id='admin-navbar' style='position: sticky; top: {$stickyOffset}; z-index: 1000;'>
     <div class='container-fluid'>
-        <span class='navbar-brand mb-0 h1'>Dashboard de Administração</span>
+        <span class='navbar-brand mb-0 h1'><img src='/assets/logo.png' alt='ClassLink' class='d-inline-block align-text-top me-2' style='height: 1.2em; width: auto;'>Dashboard de Administração</span>
         <button class='navbar-toggler' type='button' data-bs-toggle='collapse' data-bs-target='#navbarNav' aria-controls='navbarNav' aria-expanded='false' aria-label='Toggle navigation'>
             <span class='navbar-toggler-icon'></span>
         </button>


### PR DESCRIPTION
### Motivation
- Add the site logo before the admin navbar brand text to improve branding while keeping the existing spacing and alignment unchanged.

### Description
- Inserted an inline `<img>` tag with `src='/assets/logo.png'`, `class='d-inline-block align-text-top me-2'` and `style='height: 1.2em; width: auto;'` immediately before the brand text in `admin/index.php` so the logo stays inline and preserves layout.

### Testing
- Ran `php -l admin/index.php` and `git diff --check`, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49c10d6c0c83259a1957838b77d5ef)