### PR TITLE
fix(admin): align config email security fields

### DIFF
--- a/admin/config.php
+++ b/admin/config.php
@@ -92,9 +92,6 @@ $dbConfigs = get_app_config('db_configs', [
                         <input type="text" class="form-control" id="internal_email_domain" name="internal_email_domain" value="<?= htmlspecialchars($internalDomain) ?>" placeholder="exemplo.pt">
                         <div class="form-text">Domínio para reservas autónomas (sem aprovação). Deixe vazio para desativar.</div>
                     </div>
-                </div>
-                
-                <div class="row mb-3">
                     <div class="col-md-6">
                         <label for="blocked_emails_regex" class="form-label">Regex de Emails Bloqueados</label>
                         <div class="input-group">


### PR DESCRIPTION
### Motivation
- Improve the admin UI layout by placing the email-related settings side-by-side in the `Autenticação e Segurança` card so the controls align and use space more efficiently.

### Description
- Updated `admin/config.php` to merge the two separate `<div class="row mb-3">` blocks into a single `<div class="row mb-3">` containing two `<div class="col-md-6">` children, keeping labels, help text, placeholders, and the `testRegex()` button behavior unchanged.

### Testing
- Ran `php -l admin/config.php` to validate syntax and the check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49c1116ca4832581ea8aca4057349d)