### PR TITLE
fix(admin): simplify reports page text

### DIFF
--- a/admin/relatorios.php
+++ b/admin/relatorios.php
@@ -166,7 +166,7 @@ require 'index.php';
 ?>
 <div style="margin-left: 10%; margin-right: 10%; text-align: center;">
     <h3>Relatório de Utilização de Salas</h3>
-    <p>Gere um relatório em PDF da utilização de salas para um dia específico.</p>
+    <p>Gerar um relatório em PDF da utilização de salas para um dia específico.</p>
     
     <form method="POST" style="max-width: 500px; margin: 20px auto;">
         <?= csrf_token_field(); ?>
@@ -191,9 +191,4 @@ require 'index.php';
         
         <button type="submit" name="gerar_pdf" class="btn btn-primary">Gerar PDF</button>
     </form>
-    
-    <div class="alert alert-info mt-4">
-        <p><strong>Nota:</strong> Este relatório mostra as reservações para a data e sala(s) selecionada(s).</p>
-        <p>O PDF incluirá a data e hora de impressão no rodapé.</p>
-    </div>
 </div>


### PR DESCRIPTION
### Motivation
- Correct and simplify the descriptive text on the reports page and remove a redundant informational alert while keeping the existing form and PDF behavior unchanged.

### Description
- Update the paragraph text in `admin/relatorios.php` from `Gere um relatório em PDF da utilização de salas para um dia específico.` to `Gerar um relatório em PDF da utilização de salas para um dia específico.` and remove the info alert block that contained the note about reservations and the printed date/time footer; the form and PDF generation code were not modified.

### Testing
- Ran `php -l admin/relatorios.php` which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49c113dc84832581207cb72d3ffe93)