### PR TITLE
fix(admin): simplify email notification copy

### DIFF
--- a/admin/emailnotification.php
+++ b/admin/emailnotification.php
@@ -25,9 +25,7 @@ use PHPMailer\PHPMailer\Exception;
 </style>
 <div style="margin-left: 20%; margin-right: 20%; text-align: center;">
 <h1>Notificar por Email</h1>
-<p>Este script permite enviar um email para utilizadores com reservas de sala numa semana específica.</p>
-<p>Pode filtrar por sala específica ou enviar para todos os utilizadores com reservas.</p>
-<p>O email será enviado em BCC (cópia oculta) para preservar a privacidade dos destinatários.</p>
+<p>Enviar um email aos utilizadores com reservas numa semana específica.</p>
 
 <style>
     body {


### PR DESCRIPTION
### Motivation
- Make the admin email notification page copy shorter and clearer by replacing a long explanatory paragraph and removing two redundant informational paragraphs while keeping the page title and existing email behavior unchanged.

### Description
- In `admin/emailnotification.php` replace the original introductory paragraph and remove the two explanatory paragraphs with a single concise line: `Enviar um email aos utilizadores com reservas numa semana específica.`

### Testing
- Ran `php -l admin/emailnotification.php` and the file passed PHP syntax linting successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49c1158a208325ac6fc0ae73bd4acd)