### PR TITLE
fix(admin): align email sender checkbox

### DIFF
--- a/admin/emailnotification.php
+++ b/admin/emailnotification.php
@@ -546,9 +546,9 @@ $emailMode = isset($_POST['email_mode']) ? $_POST['email_mode'] : ''; // no defa
         </div>
         
         <div class="row mb-3">
-            <div class="col-md-12">
-                <div class="form-check">
-                    <input class="form-check-input" type="checkbox" id="identify_sender" name="identify_sender" value="1" <?php echo (isset($_POST['identify_sender']) && $_POST['identify_sender'] == '1') ? 'checked' : ''; ?>>
+            <div class="col-md-12 text-start">
+                <div class="form-check d-inline-flex align-items-center gap-2">
+                    <input class="form-check-input m-0" type="checkbox" id="identify_sender" name="identify_sender" value="1" <?php echo (isset($_POST['identify_sender']) && $_POST['identify_sender'] == '1') ? 'checked' : ''; ?>>
                     <label class="form-check-label" for="identify_sender">
                         Identificar-me como remetente
                     </label>


### PR DESCRIPTION
### Motivation
- Align the `identify_sender` checkbox and its label as a single left-aligned control within the email composer to improve layout and readability.

### Description
- Update `admin/emailnotification.php` markup: add `text-start` to the column, change the `form-check` wrapper to `d-inline-flex align-items-center gap-2`, and add `m-0` to the checkbox input while preserving `id="identify_sender"`, `name="identify_sender"`, and `value="1"`.

### Testing
- Ran `php -l admin/emailnotification.php` and `git diff --check`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49c117458083258f88fb48f92e8c38)