### PR TITLE
fix(admin): align TOTP config toggle

### DIFF
--- a/admin/config.php
+++ b/admin/config.php
@@ -106,14 +106,14 @@ $dbConfigs = get_app_config('db_configs', [
                 </div>
                 
                 <div class="row">
-                    <div class="col-md-12">
-                        <div class="form-check form-switch">
+                    <div class="col-md-12 text-start">
+                        <div class="form-check form-switch d-inline-block">
                             <input class="form-check-input" type="checkbox" id="admin_requires_totp" name="admin_requires_totp" value="true" <?= filter_var($adminRequiresTotp, FILTER_VALIDATE_BOOLEAN) ? 'checked' : '' ?>>
                             <label class="form-check-label" for="admin_requires_totp">
                                 <strong>Exigir TOTP para Administradores</strong>
                             </label>
-                            <div class="form-text">Se ativado, todos os administradores devem configurar e usar TOTP (autenticador) para iniciar sessão.</div>
                         </div>
+                        <div class="form-text">Se ativado, todos os administradores devem configurar e usar TOTP (autenticador) para iniciar sessão.</div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
### Motivation
- Improve the visual grouping of the admin TOTP switch and label so the control appears left-aligned and the explanatory help text sits directly beneath it using Bootstrap utilities rather than custom layout.

### Description
- Adjusted the markup in `admin/config.php` by adding `text-start` to the column and `d-inline-block` to the `.form-check.form-switch`, and moved the explanatory `.form-text` directly below the grouped switch; the checkbox `id`, `name`, and `value` (`admin_requires_totp`) are unchanged.

### Testing
- Ran `php -l admin/config.php` and there were no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49c112b578832586a5385079d1e21f)