### PR TITLE
fix(reservas): make horario badge theme-aware

### DIFF
--- a/reservas/index.php
+++ b/reservas/index.php
@@ -201,6 +201,16 @@ $stmt->close();
             margin: 0 auto;
             padding: 20px;
         }
+        .horario-badge {
+            background-color: #f8f9fa;
+            color: #212529;
+            border: 1px solid #dee2e6;
+        }
+        html[data-bs-theme="dark"] .horario-badge {
+            background-color: var(--bs-tertiary-bg);
+            color: var(--bs-body-color);
+            border-color: var(--bs-border-color);
+        }
         .reservations-table-head th {
             --bs-table-bg: var(--bs-card-bg);
             --bs-table-color: var(--bs-body-color);
@@ -397,7 +407,7 @@ $stmt->close();
                         echo "</td>";
                         
                         // Time column
-                        echo "<td><span class='badge bg-light text-dark border'>" . htmlspecialchars($tempoName, ENT_QUOTES, 'UTF-8') . "</span></td>";
+                        echo "<td><span class='badge horario-badge'>" . htmlspecialchars($tempoName, ENT_QUOTES, 'UTF-8') . "</span></td>";
                         
                         // Status column
                         echo "<td>";


### PR DESCRIPTION
### Motivation
- Ensure the Horário badge remains readable and visually consistent in both light and dark themes by replacing the hard-coded Bootstrap light badge classes with a theme-aware local class.

### Description
- In `reservas/index.php` replaced `<span class='badge bg-light text-dark border'>` with `<span class='badge horario-badge'>` and added a `.horario-badge` CSS block in the existing `<style>` with light-mode colors and a `html[data-bs-theme="dark"] .horario-badge` override for dark mode.
- Kept the existing table structure and the `$tempoName` escaping unchanged.

### Testing
- Ran `php -l reservas/index.php` which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49c4aef0ec8325bd56c31f42bcc868)